### PR TITLE
AWS CodePipeline

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,11 @@
+version: 0.2
+
+phases:
+  post_build:
+    commands:
+      - echo Build completed on `date`
+
+artifacts:
+  files:
+    - './**/*'
+  base-directory: app


### PR DESCRIPTION
There was an issue with our code pipeline where we need to only have the `app/` folder copied onto beanstalk, this should fix that. Later we can add things like collect static and build a wheel.