### PR TITLE
adds s3 storage for media files

### DIFF
--- a/app/sampl/settings_prod.py
+++ b/app/sampl/settings_prod.py
@@ -10,8 +10,8 @@ ALLOWED_HOSTS = [
 ]
 
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
-AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
+AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID_S3"]
+AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY_S3"]
 AWS_STORAGE_BUCKET_NAME = "sampl-league-storage"
 AWS_S3_REGION_NAME = "us-east-2"
 

--- a/app/sampl/settings_prod.py
+++ b/app/sampl/settings_prod.py
@@ -9,6 +9,12 @@ ALLOWED_HOSTS = [
     "samplmvp-env.eba-rhcwa63p.us-east-2.elasticbeanstalk.com",
 ]
 
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
+AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
+AWS_STORAGE_BUCKET_NAME = "sampl-league-storage"
+AWS_S3_REGION_NAME = "us-east-2"
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",

--- a/app/sampl/settings_prod.py
+++ b/app/sampl/settings_prod.py
@@ -9,7 +9,7 @@ ALLOWED_HOSTS = [
     "samplmvp-env.eba-rhcwa63p.us-east-2.elasticbeanstalk.com",
 ]
 
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
 AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
 AWS_STORAGE_BUCKET_NAME = "sampl-league-storage"


### PR DESCRIPTION
For now, I will use my aws key for testing, but we will want to make a user that has no console access with this IAM policy:

https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#iam-policy

For this first pass I didn't want to do anything too fancy, but see settings here:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
We may for example want to look at using a subdirectory on s3 per challenge. 