### PR TITLE
add rollbar to work in production

### DIFF
--- a/app/Pipfile
+++ b/app/Pipfile
@@ -14,6 +14,7 @@ docker = "*"
 six = "*"
 ever-given = "0.0.2"
 sampl = {path = "."}
+rollbar = "*"
 
 [dev-packages]
 black = "==20.8b1"

--- a/app/Pipfile.lock
+++ b/app/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5faffb4a0a072c07000b4c6142ee18f43b2cda6909be7b6e57358233468411fd"
+            "sha256": "c190b851fa958908776d598be8e93ab65ccc2138b4c35e4e29640c9ee8960a19"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -324,6 +324,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.26.0"
+        },
+        "rollbar": {
+            "hashes": [
+                "sha256:edaa0f36c7f5f10e8205de49f71c0c335b95eb6448fbf2cd3ebe9cc8b3092c66"
+            ],
+            "index": "pypi",
+            "version": "==0.16.1"
         },
         "sampl": {
             "path": "."

--- a/app/sampl/settings_prod.py
+++ b/app/sampl/settings_prod.py
@@ -2,8 +2,13 @@ import os
 
 from .base_settings import *  # lgtm [py/polluting-import]
 
+# We only need rollbar in production
+MIDDLEWARE.append("rollbar.contrib.django.middleware.RollbarNotifierMiddleware")
+
 DEBUG = False
 SECRET_KEY = os.environ["SAMPL_SECRET_KEY"]
+# Rollbar API key
+POST_SERVER_ITEM_ACCESS_TOKEN = os.environ["POST_SERVER_ITEM_ACCESS_TOKEN"]
 ALLOWED_HOSTS = [
     "app.samplchallenges.org",
     "samplmvp-env.eba-rhcwa63p.us-east-2.elasticbeanstalk.com",
@@ -26,6 +31,14 @@ DATABASES = {
     }
 }
 
+# rollbar settings
+ROLLBAR = {
+    "access_token": POST_SERVER_ITEM_ACCESS_TOKEN,
+    "environment": "production",
+    "branch": "main",
+    "root": BASE_DIR,
+}
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -35,25 +48,31 @@ LOGGING = {
             "class": "logging.FileHandler",
             "filename": "/var/log/app.log",
         },
+        "rollbar": {
+            "filters": ["require_debug_false"],
+            "access_token": POST_SERVER_ITEM_ACCESS_TOKEN,
+            "environment": "production",
+            "class": "rollbar.logger.RollbarHandler",
+        },
     },
     "loggers": {
         "django": {
-            "handlers": ["file"],
+            "handlers": ["file", "rollbar"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
         "core": {
-            "handlers": ["file"],
+            "handlers": ["file", "rollbar"],
             "level": os.getenv("SAMPL_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
         "referee": {
-            "handlers": ["file"],
+            "handlers": ["file", "rollbar"],
             "level": os.getenv("SAMPL_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
         "ever_given": {
-            "handlers": ["file"],
+            "handlers": ["file", "rollbar"],
             "level": os.getenv("SAMPL_LOG_LEVEL", "INFO"),
             "propagate": False,
         },


### PR DESCRIPTION
Adds https://rollbar.com which will make it easier to see errors happening in production, once it is working I'll invite the team to the project so we call can view the errors. The free tier gives us 25K error events a month which should be plenty. 