### PR TITLE
make install editable

### DIFF
--- a/app/Pipfile
+++ b/app/Pipfile
@@ -14,7 +14,7 @@ distributed = "*"
 docker = "*"
 six = "*"
 ever-given = "0.0.5"
-sampl = {path = "."}
+sampl = {path = ".", editable = true}
 rollbar = "*"
 jupyterlab = "*"
 


### PR DESCRIPTION
fixes annoying issue where install is not like `pipe install -e .` or `python setup.py develop`