### PR TITLE
Fix issue with rollbar

### DIFF
--- a/app/sampl/settings_prod.py
+++ b/app/sampl/settings_prod.py
@@ -40,7 +40,7 @@ ROLLBAR = {
     "access_token": POST_SERVER_ITEM_ACCESS_TOKEN,
     "environment": "production",
     "branch": "main",
-    "root": BASE_DIR,
+    "root": str(BASE_DIR),
 }
 
 LOGGING = {


### PR DESCRIPTION
rollbar library is expecting a str for the configuration variable 'root', but django's settings.BASE_DIR is a PosixPath, casting to str to fix AttributeError: 'PosixPath' object has no attribute 'lower'