### PR TITLE
Allow for overwriting scores, Add functionality to resubmit batch

### DIFF
--- a/app/core/models/run_related.py
+++ b/app/core/models/run_related.py
@@ -166,6 +166,9 @@ class BaseEvaluation(Logged):
     def clear_old_predictions(self, output_type):
         raise Exception("Must implement in subclass")
 
+    def clear_old_scores(self):
+        raise Exception("Must implement in subclass")
+
     def mark_started(self):
         self.append(stdout="Started\n")
         self.status = Status.RUNNING
@@ -201,6 +204,10 @@ class Evaluation(BaseEvaluation):
         if matching_prediction.exists():
             self.append(stderr="Duplicate prediction entry, overwriting old entry")
             matching_prediction.delete()
+
+    def clear_old_scores(self):
+        if self.scores.exists():
+            self.scores.delete()
 
     def cleanup_local_outputs(self, output_file_keys):
         # TODO: copied between this and BatchEvaluation with minor changes
@@ -364,6 +371,10 @@ class BatchEvaluation(BaseEvaluation):
         if matching_objects.exists():
             self.append(stderr="Duplicate prediction entry, overwriting old entry")
             matching_objects.delete()
+
+    def clear_old_scores(self):
+        if self.scores.exists():
+            self.scores.delete()
 
     def cleanup_local_outputs(self, output_file_keys):
         for prediction in Prediction.objects.filter(

--- a/app/core/models/run_related.py
+++ b/app/core/models/run_related.py
@@ -167,7 +167,7 @@ class BaseEvaluation(Logged):
         raise Exception("Must implement in subclass")
 
     def clear_old_scores(self):
-        raise Exception("Must implement in subclass")
+        self.scores.delete()
 
     def mark_started(self):
         self.append(stdout="Started\n")
@@ -204,10 +204,6 @@ class Evaluation(BaseEvaluation):
         if matching_prediction.exists():
             self.append(stderr="Duplicate prediction entry, overwriting old entry")
             matching_prediction.delete()
-
-    def clear_old_scores(self):
-        if self.scores.exists():
-            self.scores.delete()
 
     def cleanup_local_outputs(self, output_file_keys):
         # TODO: copied between this and BatchEvaluation with minor changes
@@ -371,10 +367,6 @@ class BatchEvaluation(BaseEvaluation):
         if matching_objects.exists():
             self.append(stderr="Duplicate prediction entry, overwriting old entry")
             matching_objects.delete()
-
-    def clear_old_scores(self):
-        if self.scores.exists():
-            self.scores.delete()
 
     def cleanup_local_outputs(self, output_file_keys):
         for prediction in Prediction.objects.filter(

--- a/app/referee/job_submitter.py
+++ b/app/referee/job_submitter.py
@@ -115,6 +115,15 @@ def reset_unfinished_to_pending_submission():
                             "   Evaluation status is now: %s", evaluation.status
                         )
 
+                for batch_evaluation in submission_run.batchevaluation_set.select_for_update():
+                    if batch_evaluation.status == Status.RUNNING:
+                        logger.debug(
+                            "   BATCHEVAL: Resetting RUNNING back to PENDING: %d", batch_evaluation.id
+                        )
+                        batch_evaluation.update_status(Status.PENDING)
+                        logger.debug(
+                            "   BATCHEVAL: Evaluation status is now: %s", batch_evaluation.status
+                        )
 
 def job_submitter_main():
     start_time = time.time()

--- a/app/referee/job_submitter.py
+++ b/app/referee/job_submitter.py
@@ -115,15 +115,20 @@ def reset_unfinished_to_pending_submission():
                             "   Evaluation status is now: %s", evaluation.status
                         )
 
-                for batch_evaluation in submission_run.batchevaluation_set.select_for_update():
+                for (
+                    batch_evaluation
+                ) in submission_run.batchevaluation_set.select_for_update():
                     if batch_evaluation.status == Status.RUNNING:
                         logger.debug(
-                            "   BATCHEVAL: Resetting RUNNING back to PENDING: %d", batch_evaluation.id
+                            "   BATCHEVAL: Resetting RUNNING back to PENDING: %d",
+                            batch_evaluation.id,
                         )
                         batch_evaluation.update_status(Status.PENDING)
                         logger.debug(
-                            "   BATCHEVAL: Evaluation status is now: %s", batch_evaluation.status
+                            "   BATCHEVAL: Evaluation status is now: %s",
+                            batch_evaluation.status,
                         )
+
 
 def job_submitter_main():
     start_time = time.time()

--- a/app/referee/job_submitter.py
+++ b/app/referee/job_submitter.py
@@ -98,20 +98,20 @@ def reset_unfinished_to_pending_submission():
             for submission_run in SubmissionRun.objects.select_for_update().filter(
                 status=status
             ):
-                logger.debug(
+                logger.info(
                     "Resetting PENDING/RUNNING submission_runs back to PENDING_REMOTE: %d",
                     submission_run.id,
                 )
                 submission_run.update_status(Status.PENDING_REMOTE)
-                logger.debug("SubmissionRun status is now: %s", submission_run.status)
+                logger.info("SubmissionRun status is now: %s", submission_run.status)
 
                 for evaluation in submission_run.evaluation_set.select_for_update():
                     if evaluation.status == Status.RUNNING:
-                        logger.debug(
+                        logger.info(
                             "   Resetting RUNNING back to PENDING: %d", evaluation.id
                         )
                         evaluation.update_status(Status.PENDING)
-                        logger.debug(
+                        logger.info(
                             "   Evaluation status is now: %s", evaluation.status
                         )
 
@@ -119,12 +119,12 @@ def reset_unfinished_to_pending_submission():
                     batch_evaluation
                 ) in submission_run.batchevaluation_set.select_for_update():
                     if batch_evaluation.status == Status.RUNNING:
-                        logger.debug(
+                        logger.info(
                             "   BATCHEVAL: Resetting RUNNING back to PENDING: %d",
                             batch_evaluation.id,
                         )
                         batch_evaluation.update_status(Status.PENDING)
-                        logger.debug(
+                        logger.info(
                             "   BATCHEVAL: Evaluation status is now: %s",
                             batch_evaluation.status,
                         )

--- a/app/referee/jobqueue.yaml
+++ b/app/referee/jobqueue.yaml
@@ -7,7 +7,7 @@ jobqueue:
 
       # Dask worker options
       cores: 1                    # Total number of cores per job
-      memory: '4 GB'              # Total amount of memory per job
+      memory: '8 GB'              # Total amount of memory per job
       processes: 1                # Number of Python processes per job
 
       #interface: null             # Network interface to use like eth0 or ib0
@@ -19,7 +19,7 @@ jobqueue:
       shebang: "#!/usr/bin/env bash"
       queue: 'free'                # Queue to use: 'free' or 'standard' if standard is used project must be DMOBLEY_LAB
       #project: 'DMOBLEY_LAB'
-      walltime: '02:00:00'
+      walltime: '06:00:00'
       #env-extra: []
       #job-cpu: null
       #job-mem: null
@@ -30,6 +30,6 @@ jobqueue:
 
     adapt_settings:
       minimum_jobs: 0
-      maximum_jobs: 1
+      maximum_jobs: 50
       wait_count: 3
       interval: '30000 ms'

--- a/app/referee/scoring.py
+++ b/app/referee/scoring.py
@@ -110,7 +110,8 @@ def score_element(
                 )
     except Exception as exc:  # pylint: disable=broad-except
         log_messages.append(f"Scoring failed: {exc}")
-        raise ScoringFailureException from exc
+        err_message = f"Scoring failed: {exc}"
+        raise ScoringFailureException(err_message)
     log_messages.append(f"Scoring completed for {input_element.name}\n")
     return log_messages
 

--- a/app/referee/scoring.py
+++ b/app/referee/scoring.py
@@ -111,7 +111,7 @@ def score_element(
     except Exception as exc:  # pylint: disable=broad-except
         log_messages.append(f"Scoring failed: {exc}")
         err_message = f"Scoring failed: {exc}"
-        raise ScoringFailureException(err_message)
+        raise ScoringFailureException(err_message) from exc
     log_messages.append(f"Scoring completed for {input_element.name}\n")
     return log_messages
 

--- a/app/referee/tasks.py
+++ b/app/referee/tasks.py
@@ -235,6 +235,8 @@ def run_eval_or_batch(submission_id, cls, object_id, submission_run_id, conditio
             input_elements = list(obj.input_batch.elements())
         else:
             input_elements = [obj.input_element]
+
+        obj.clear_old_scores()
         for input_element in input_elements:
             # TODO: batch up scoring?
             for log_message in scoring.score_element(


### PR DESCRIPTION
* run_related.py -> Add clear_old_scores() method, to clear scores
when job_submitter restarts after a batch has started scoring
* job_submitter.py -> Adds batch resubmission functionality when
job_submitter needs to restart due to time limit
* jobqueue.yaml -> Upgrade memory, worker walltime, and max workers
* scoring.py -> Add information for when an error occurs during
scoring. Previously, "Error scoring: " with no information about
the error
* tasks.py -> clear_old_scores() before beginning scoring